### PR TITLE
Special case: render method

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,10 @@ var wrapWithTryCatch = function wrapWithTryCatch(component, method) {
       if (arguments.length > 0) {
         errorReport.arguments = arguments;
       }
-      config.errorHandler(errorReport);
+      var returnValue = config.errorHandler(errorReport);
+      if (method === 'render') {
+        return returnValue || React.createElement('h1', {}, 'error');
+      }
     }
   };
 


### PR DESCRIPTION
Good job for the wrapper ! That's exactly what I need.

I added the posibility to return the handler value in the render method. If none, a default `<h1>error</h1>` is returned. This is to avoid:

```
Uncaught Invariant Violation: Component.render(): A valid ReactComponent must be returned.
You may have returned undefined, an array or some other invalid object.
```

I'm working on this right now and that would solve my last problem :)
https://github.com/yormi/AsyncIt
